### PR TITLE
Move the config file to where the builder can see it

### DIFF
--- a/.github/workflows/site-from-template.yaml
+++ b/.github/workflows/site-from-template.yaml
@@ -30,6 +30,9 @@ jobs:
       - name: "Move docs into content directory"
         run: rm -rf src/content/docs/; mv content_repo/docs src/content/
 
+      - name: "Move up config.toml"
+        run: mv content_repo/config.toml .
+
       - name: "Update placeholder values"
         run: python init_template.py
 


### PR DESCRIPTION
That was a fun one.
Accidentally committed the config file I was using for testing so I didn't notice that I wasn't actually getting the one in the running repo: https://github.com/letsbuildawiki/template/blob/596c419080b2df72cd76ca4c4f9aecb615b73e12/config.toml